### PR TITLE
Reconfigure Spi new functions for better type inference

### DIFF
--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -20,7 +20,7 @@ use rp2040_hal as hal;
 // Some traits we need
 use core::fmt::Write;
 use embedded_hal::adc::OneShot;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -13,12 +13,12 @@
 // be linked)
 use panic_halt as _;
 
-// Some traits we need
-use embedded_hal::blocking::i2c::Write;
-use fugit::RateExtU32;
-
 // Alias for our HAL crate
 use rp2040_hal as hal;
+
+// Some traits we need
+use embedded_hal::blocking::i2c::Write;
+use hal::fugit::RateExtU32;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access and a gpio related types.

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -22,7 +22,7 @@ use hal::pac;
 
 // Some traits we need
 use core::fmt::Write;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use hal::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -21,8 +21,8 @@ use rp2040_hal as hal;
 
 // Some traits we need
 use cortex_m::prelude::*;
-use fugit::RateExtU32;
-use rp2040_hal::clocks::Clock;
+use hal::clocks::Clock;
+use hal::fugit::RateExtU32;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access

--- a/rp2040-hal/examples/spi_dma.rs
+++ b/rp2040-hal/examples/spi_dma.rs
@@ -12,8 +12,8 @@
 use cortex_m::singleton;
 use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
-use fugit::RateExtU32;
 use hal::dma::{bidirectional, DMAExt};
+use hal::fugit::RateExtU32;
 use hal::pac;
 use panic_halt as _;
 use rp2040_hal as hal;

--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -24,7 +24,7 @@ use hal::pac;
 
 // Some traits we need
 use core::fmt::Write;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::clocks::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/uart_dma.rs
+++ b/rp2040-hal/examples/uart_dma.rs
@@ -24,7 +24,7 @@ use rp2040_hal as hal;
 use hal::{dma::DMAExt, pac};
 
 // Some traits we need
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::clocks::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/vector_table.rs
+++ b/rp2040-hal/examples/vector_table.rs
@@ -22,7 +22,7 @@ use hal::pac;
 use core::cell::RefCell;
 use critical_section::Mutex;
 use embedded_hal::digital::v2::ToggleableOutputPin;
-use fugit::MicrosDurationU32;
+use hal::fugit::MicrosDurationU32;
 use pac::interrupt;
 use rp2040_hal::clocks::Clock;
 use rp2040_hal::timer::Alarm;

--- a/rp2040-hal/examples/watchdog.rs
+++ b/rp2040-hal/examples/watchdog.rs
@@ -23,7 +23,7 @@ use hal::pac;
 // Some traits we need
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::watchdog::{Watchdog, WatchdogEnable};
-use fugit::ExtU32;
+use hal::fugit::ExtU32;
 use rp2040_hal::clocks::Clock;
 
 /// The linker will place this boot block at the start of our program image. We

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -38,6 +38,7 @@
 #![warn(missing_docs)]
 #![no_std]
 
+#[doc(hidden)]
 pub use paste;
 
 /// Re-export of the PAC

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -93,6 +93,8 @@ pub use sio::Sio;
 pub use spi::Spi;
 pub use timer::Timer;
 pub use watchdog::Watchdog;
+// Re-export crates used in rp2040-hal's public API
+pub extern crate fugit;
 
 /// Trigger full reset of the RP2040.
 ///

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -254,6 +254,11 @@ impl<S: State, D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<S, D, P, DS
 impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
     /// Create new not initialized Spi bus. Initialize it with [`.init`][Self::init]
     /// or [`.init_slave`][Self::init_slave].
+    ///
+    /// Valid pin sets are in the form of `(Tx, Sck)` or `(Tx, Rx, Sck)`
+    ///
+    /// If you pins are dynamically identified (`Pin<DynPinId, _, _>`) they will first need to pass
+    /// validation using their corresponding [`ValidatedPinXX`](ValidatedPinTx).
     pub fn new(device: D, pins: P) -> Spi<Disabled, D, P, DS> {
         Spi {
             device,

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -269,21 +269,22 @@ impl<D: SpiDevice, P: ValidSpiPinout<D>> Spi<Disabled, D, P, 8> {
             state: PhantomData,
         }
     }
+}
 
-    /// Create new (not initialized) Spi bus with a non-default data size.
+impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
+    /// Create new (not initialized) Spi bus with a non-default data size, provided
+    /// as a const generic parameter.
     ///
     /// Initialize it with [`.init`][Self::init]
     /// or [`.init_slave`][Self::init_slave].
-    pub fn new_with_data_size<const DS: u8>(device: D, pins: P) -> Spi<Disabled, D, P, DS> {
+    pub fn new_with_data_size<const DATA_SIZE: u8>(device: D, pins: P) -> Spi<Disabled, D, P, DATA_SIZE> {
         Spi {
             device,
             pins,
             state: PhantomData,
         }
     }
-}
 
-impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
     /// Set format and datasize
     fn set_format(&mut self, data_bits: u8, frame_format: FrameFormat) {
         self.device.sspcr0.modify(|_, w| unsafe {


### PR DESCRIPTION
A slight breaking change but means better ergonomics of specifying types for `Spi`